### PR TITLE
Native Type Generation Support

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -70,6 +70,10 @@ func packNumber(num Number) []byte {
     binary.LittleEndian.PutUint32(b, uint32(num))
     return b
 }
+
+func UnpackByte(b Byte) byte {
+    return b.inner
+}
                     "#,
             );
 


### PR DESCRIPTION
# What does this PR do
Brings the ability to generate native type conversion code for user defined types, gives a general interface that can easily integrated into legacy codes.

## Example
Assume that we have a definition 

```
struct StructA {
    f1: byte,
    f2: byte,
}
```
It will generates following codes:
```go
type NativeStructA struct {
      // Note that *Byte is moleculec defined type, not the go intergrated `byte` type. Performs the same if you have a more complicated defined custom type
	F1 *Byte  `json:"f1"`
	F2 *Byte  `json:"f2"`
}

func UnpackStructA(v *StructA) *NativeStructA {
	native_val := &NativeStructA{}
	//s := v.AsBuilder()
	native_val.F1 = v.F1()
	native_val.F2 = v.F2()
	return native_val
}
```

Other mol internal types are mostly performs the same, users can use the `test/schema/types.mol` to generate and can explain the behaviour

## How to use
Still the example of `StructA`, at the past we need to hand write our own native mapping structures and the Unpack func, now we can simply use the definition of `NativeStuctA` to stands the go type. And if the json fields name does not feats the meet, users can:
```go
type MyPersonalStructA struct {
    	F1 *Byte  `json:"new_field_f1"`
	F2 *Byte  `json:"new_field_f2"`
}
```
and initialize it with:
```go
// We have a NativeStructA
generated_a = &NativeStructA{}
//... other codes
personal_struct_a = MyPersonalStruct(generated_a)
```